### PR TITLE
Add Asciidoctor workflow

### DIFF
--- a/.github/workflows/asciidoctor.yml
+++ b/.github/workflows/asciidoctor.yml
@@ -1,0 +1,20 @@
+name: Asciidoctor
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish_gh_pages:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Run Asciidoctor
+      run: ./gradlew asciidoctor
+    - name: Publish to GitHub Pages
+      run: ./gradlew publishGhPages -PgithubToken=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds automatic publishing to GitHub Pages for each push event on `master`.
No token has to be defined as `GITHUB_TOKEN` is [available out of the box](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token).

Open point:
- [ ] the author of the commit does not reflect the user who triggered the build (see https://github.com/assertj/doc/commit/c34535b7fe172c7c9c8747bb2585aa73ee9dfb67)