### PR TITLE
Replace deprecated github-pages plugin with git-publish plugin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,6 @@ jobs:
       run: ./gradlew asciidoctor
     - name: Publish to GitHub Pages
       run: |
-        git config user.name '${{ github.actor }}'
-        git config user.email '${{ github.actor }}@users.noreply.github.com'
-        ./gradlew --stacktrace  --info publishGhPages -PgithubToken=${{ secrets.ASCIIDOCTOR_TOKEN }}
+        ./gradlew --stacktrace  --info gitPublishPush
+      env:
+        GRGIT_USER: ${{ secrets.ASCIIDOCTOR_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.ajoberstar.github-pages' version '1.7.2'
+	id 'org.ajoberstar.git-publish' version '2.1.3'
 	id 'org.asciidoctor.convert' version '2.4.0'
 }
 
@@ -56,14 +56,10 @@ asciidoctor {
 			'docinfo': 'shared'
 }
 
-githubPages {
+gitPublish {
 	repoUri = 'https://github.com/assertj/doc.git'
-	credentials {
-		username = project.hasProperty('githubToken') ? project.githubToken : ''
-		password = ''
-	}
-
-	pages {
+	branch = 'gh-pages'
+	contents {
 		from file(asciidoctor.outputDir.path + '/user-guide')
 	}
 }


### PR DESCRIPTION
`git-publish` uses `grgit` under the hood, therefore the [authentication](http://ajoberstar.org/grgit/grgit-authentication.html) should be updated accordingly:
* The workflow now uses  the`GRGIT_USER` environment property
* For the local environment, either the `GRGIT_USER` env property can be used or the former `githubToken` property in the local `gradle.properties` can be replaced with `systemProp.org.ajoberstar.grgit.auth.username`

Result from local environment: a2b37acd67aee6a1f0d27553c3b8ac2c8800710e

This **does not** solve #32 but `grgit` could offer more options to address it.