### PR TITLE
Removed bdd from method name of non-bdd method

### DIFF
--- a/src/test/java/example/core/JUnit5SoftAssertionsExample.java
+++ b/src/test/java/example/core/JUnit5SoftAssertionsExample.java
@@ -31,7 +31,7 @@ public class JUnit5SoftAssertionsExample {
   @ParameterizedTest
   @CsvSource({ "1, 1, 2", "1, 2, 3" })
   // test parameters come first, soft assertion must come last.
-  void junit5_bdd_soft_assertions_parameterized_test_example(int a, int b, int sum, SoftAssertions softly) {
+  void junit5_soft_assertions_parameterized_test_example(int a, int b, int sum, SoftAssertions softly) {
     softly.assertThat(a + b).as("sum").isEqualTo(sum);
     softly.assertThat(a).isLessThan(sum);
     softly.assertThat(b).isLessThan(sum);


### PR DESCRIPTION
In what looks like a cut-and-paste error, the example included "bdd" in the method name when it used plain "assertThat" syntax.