### PR TITLE
fix typo in `assertj-core-release-notes.adoc`

### DIFF
--- a/src/docs/asciidoc/user-guide/assertj-core-release-notes.adoc
+++ b/src/docs/asciidoc/user-guide/assertj-core-release-notes.adoc
@@ -298,7 +298,7 @@ Example: the following failing assertion ...
 InputStream inputStream = new ByteArrayInputStream(new byte[] {1, 2});
 
 // assertion will pass
-assertThat(inputStream).hasContent(new byte[] {1, 2});
+assertThat(inputStream).hasBinaryContent(new byte[] {1, 2});
 
 // assertions will fail
 assertThat(inputStream).hasBinaryContent(new byte[] { });


### PR DESCRIPTION
issues: #56 