### PR TITLE
Gradle 7.0.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 7.0.1 is available.

This is sent by @gradleupdate. See https://gradleupdate.appspot.com/assertj/doc/status for more.