### PR TITLE
Fix word absence

### DIFF
--- a/src/docs/asciidoc/user-guide/assertj-core-assertions-guide.adoc
+++ b/src/docs/asciidoc/user-guide/assertj-core-assertions-guide.adoc
@@ -194,7 +194,7 @@ Assertions:
 [[assertj-core-overriding-error-message]]
 ==== Overriding error message
 
-AssertJ tries its best to give helpful error messages but you always change it with `overridingErrorMessage()` or `withFailMessage()`.
+AssertJ tries its best to give helpful error messages, but you can always change it with `overridingErrorMessage()` or `withFailMessage()`.
 
 Example with this failing test:
 [source,java,indent=0]


### PR DESCRIPTION
I'm not a native speaker, but I think that this sentence missing a word 'can'
> AssertJ tries its best to give helpful error messages but you always change it with `overridingErrorMessage()` or `withFailMessage()`.

Fixes #109.