### PR TITLE
Fix example for filteredOnNull

### DIFF
--- a/src/docs/asciidoc/user-guide/assertj-core-assertions-guide.adoc
+++ b/src/docs/asciidoc/user-guide/assertj-core-assertions-guide.adoc
@@ -1025,7 +1025,7 @@ TolkienCharacter mysteriousHobbit = new TolkienCharacter(null, 38, HOBBIT);
 
 List<TolkienCharacter> hobbits = list(frodo, mysteriousHobbit, merry, pippin);
 
-assertThat(hobbits).filteredOnNull("age"))
+assertThat(hobbits).filteredOnNull("name"))
                    .singleElement()
                    .isEqualTo(mysteriousHobbit);
 ----


### PR DESCRIPTION
It is the name that is null, but the example filters on age.