### PR TITLE
Add JVM options to prevent warnings with Asciidoctor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ ext {
 
 asciidoctor {
 
+	forkOptions {
+		jvmArgs("--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens", "java.base/java.io=ALL-UNNAMED")
+	}
+
 	baseDirFollowsSourceFile()
 
 	sources {


### PR DESCRIPTION
Add the necessary configuration to avoid the warning.

Fixes #150