### PR TITLE
Fix URLs to JavaDoc

### DIFF
--- a/src/docs/asciidoc/link-attributes.adoc
+++ b/src/docs/asciidoc/link-attributes.adoc
@@ -1,8 +1,9 @@
-:assertj-core-javadoc-root:              https://www.javadoc.io/doc/org.assertj/assertj-core/latest/
-:assertj-guava-javadoc-root:             https://www.javadoc.io/doc/org.assertj/assertj-guava/latest/
+:assertj-core-javadoc-root:              https://www.javadoc.io/doc/org.assertj/assertj-core/latest/org.assertj.core/
+:assertj-guava-javadoc-root:             https://www.javadoc.io/doc/org.assertj/assertj-guava/latest/org.assertj.guava/
 :assertj-joda-time-javadoc-root:         https://www.javadoc.io/doc/org.assertj/assertj-joda-time/latest/
 //
 :assertj-core-repo:                      https://github.com/assertj/assertj
+:assertj-doc:                            https://github.com/assertj/doc
 :assertj-examples-repo:                  https://github.com/assertj/assertj-examples
 :assertj-examples-base-package:          https://github.com/assertj/assertj-examples/blob/main/assertions-examples/src/test/java/org/assertj/examples/
 :assertj-guava-repo:                     https://github.com/assertj/assertj

--- a/src/docs/asciidoc/user-guide/assertj-core-assertions-guide.adoc
+++ b/src/docs/asciidoc/user-guide/assertj-core-assertions-guide.adoc
@@ -758,19 +758,19 @@ expected: JEDI [name=Luke, age=23]
 [[assertj-core-common-assertions]]
 ==== Common assertions
 
-This section describes the assertions common to all types, the Javadoc for common assertions methods is available https://www.javadoc.io/static/org.assertj/assertj-core/{assertj-version}/org/assertj/core/api/AbstractAssert.html#method.summary[here].
+This section describes the assertions common to all types, the Javadoc for common assertions methods is available {assertj-core-javadoc-root}org/assertj/core/api/AbstractAssert.html#method.summary[here].
 
 [[assertj-core-object-assertions]]
 ==== Object assertions
 
-The Javadoc for `Object` assertions is available https://www.javadoc.io/static/org.assertj/assertj-core/{assertj-version}/org/assertj/core/api/AbstractObjectAssert.html#method.summary[here].
+The Javadoc for `Object` assertions is available {assertj-core-javadoc-root}org/assertj/core/api/AbstractObjectAssert.html#method.summary[here].
 
 [[assertj-string-object-assertions]]
 ==== String/CharSequence assertions
 
 This section describes all the available assertions for `CharSequence` (including `String`, `StringBuilder`, `StringBuffer`, ...):
 
-The Javadoc for `CharSequence` assertions is available https://www.javadoc.io/static/org.assertj/assertj-core/{assertj-version}/org/assertj/core/api/AbstractCharSequenceAssert.html#method.summary[here].
+The Javadoc for `CharSequence` assertions is available {assertj-core-javadoc-root}org/assertj/core/api/AbstractCharSequenceAssert.html#method.summary[here].
 
 
 [[assertj-core-group-assertions]]
@@ -1269,7 +1269,7 @@ If you use java 7, check the link:#assertj-core-exception-assertions-java-7[Java
 
 There are various ways for checking the exception message content, you can check the exact message, what it contains, its start, its end, if it matches a regex.
 
-Most of the assertions expecting a `String` can use the https://docs.oracle.com/javase/8/docs/api/java/lang/String.html?is-external=true#format-java.lang.String-java.lang.Object...-[String.format] syntax.
+Most of the assertions expecting a `String` can use the https://docs.oracle.com/javase/8/docs/api/java/lang/String.html?is-external=true#format-java.lang.String-java.lang.Object\...-[String.format] syntax.
 
 Examples:
 [source,java]

--- a/src/docs/asciidoc/user-guide/assertj-core-extension.adoc
+++ b/src/docs/asciidoc/user-guide/assertj-core-extension.adoc
@@ -6,7 +6,7 @@ AssertJ can be extends by Condition or writing your own assertions class.
 [[assertj-core-conditions]]
 ==== Conditions
 
-Assertions can be extended by using conditions, to create a condition you just have to implement https://www.javadoc.io/doc/org.assertj/assertj-core/latest/org/assertj/core/api/Condition.html[`org.assertj.assertions.core.Condition`] and its unique method matches.
+Assertions can be extended by using conditions, to create a condition you just have to implement {assertj-core-javadoc-root}org/assertj/core/api/Condition.html[`org.assertj.assertions.core.Condition`] and its unique method matches.
 
 Once your Condition is created, you can use it with methods: `is(myCondition)` or `has(myCondition)`, both verifying that the condition is met (hint: pick the one that makes your code more readable).
 
@@ -32,7 +32,7 @@ You can verify that a Condition is met on elements of a collection, with the fol
 
 Moreover all Condition related methods have their negation counterpart, `is`/`isNot`, `have`/`doesNotHave`, `are`/`areNot`, ...
 
-The examples below are from https://github.com/assertj/assertj-examples/[assertj-examples] and more specifically https://github.com/assertj/assertj-examples/blob/main/assertions-examples/src/test/java/org/assertj/examples/condition/UsingConditionExamples.java[UsingConditionExamples.java].
+The examples below are from {assertj-examples}/[assertj-examples] and more specifically {assertj-examples-base-package}condition/UsingConditionExamples.java[UsingConditionExamples.java].
 
 [[assertj-core-condition-creation]]
 ===== Creating a Condition
@@ -46,7 +46,7 @@ import static org.assertj.core.util.Sets.newLinkedHashSet;
 static Set<String> JEDIS = newLinkedHashSet("Luke", "Yoda", "Obiwan");
 
 // implementation with Java 8 lambda
-Condition<String> jediPower = new Condition<>(JEDIS::contains, "jedi power"); 
+Condition<String> jediPower = new Condition<>(JEDIS::contains, "jedi power");
 
 // implementation with Java 7
 Condition<String> jedi = new Condition<String>("jedi") {
@@ -115,7 +115,7 @@ Let's define a sith condition:
 [source,java]
 ----
 List<String> SITHS = list("Sidious", "Vader", "Plagueis");
-Condition<String> sith = new Condition<>(SITHS::contains, "sith"); 
+Condition<String> sith = new Condition<>(SITHS::contains, "sith");
 ----
 
 We can write these assertions:
@@ -147,7 +147,7 @@ Sections:
 
 Let's see how to do that with an example!
 
-The example is taken from https://github.com/assertj/assertj-examples/[assertj-examples] and more specifically https://github.com/assertj/assertj-examples/blob/main/assertions-examples/src/test/java/org/assertj/examples/custom/TolkienCharacterAssert.java[TolkienCharacterAssert.java].
+The example is taken from {assertj-examples}/[assertj-examples] and more specifically {assertj-examples-base-package}custom/TolkienCharacterAssert.java[TolkienCharacterAssert.java].
 
 We want to have assertion for the `TolkienCharacter` domain model class shown below:
 [source,java]
@@ -210,7 +210,7 @@ public class TolkienCharacterAssert extends AbstractAssert<TolkienCharacterAsser
 To use our custom assertion class, simply call the `assertThat` factory method with the object to test:
 [source,java]
 ----
-// use assertThat from TolkienCharacterAssert to check TolkienCharacter 
+// use assertThat from TolkienCharacterAssert to check TolkienCharacter
 TolkienCharacterAssert.assertThat(frodo).hasName("Frodo");
 
 // code is more elegant when TolkienCharacterAssert.assertThat is imported statically :
@@ -222,19 +222,19 @@ Well, that was not too difficult, but having to add a static import for each `as
 [[assertj-core-custom-assertions-entry-point]]
 ===== Providing an entry point for all custom assertions
 
-Now that you have a bunch of custom assertions classes, you want to access them easily. Just create a `CustomAssertions` class providing static `assertThat` methods for each of your assertions classes. 
+Now that you have a bunch of custom assertions classes, you want to access them easily. Just create a `CustomAssertions` class providing static `assertThat` methods for each of your assertions classes.
 
 Example:
 [source,java]
 ----
 public class MyProjectAssertions {
 
-  // give access to TolkienCharacter assertion 
+  // give access to TolkienCharacter assertion
   public static TolkienCharacterAssert assertThat(TolkienCharacter actual) {
     return new TolkienCharacterAssert(actual);
   }
 
-  // give access to TolkienCharacter Race assertion 
+  // give access to TolkienCharacter Race assertion
   public static RaceAssert assertThat(Race actual) {
     return new RaceAssert(actual);
   }
@@ -272,7 +272,7 @@ import static my.project.MyOtherAssertions.assertThat;
 @Test
 public void ambiguous_assertThat_resolution() {
   // ERROR: assertThat(String) is ambiguous!
-  // assertThat(String) is available from MyAssertions AND MyOtherAssertions 
+  // assertThat(String) is available from MyAssertions AND MyOtherAssertions
   // (it is defined in Assertions the class both MyAssertions and MyOtherAssertions inherits from)
   assertThat("frodo").contains("do");
 }

--- a/src/docs/asciidoc/user-guide/assertj-core-release-notes.adoc
+++ b/src/docs/asciidoc/user-guide/assertj-core-release-notes.adoc
@@ -3,7 +3,7 @@
 
 NOTE: AssertJ Core would not exist without its contributors, you can find them all {assertj-core-repo}/graphs/contributors[directly on GitHub].
 
-The latest release notes can be found in the https://github.com/assertj/assertj/releases[GitHub releases].
+The latest release notes can be found in the {assertj-core-repo}/releases[GitHub releases].
 
 Older release notes:
 
@@ -1028,13 +1028,13 @@ This method is used with `usingFieldByFieldElementComparator()` which is depreca
 
 When using `usingRecursiveComparison()` the equivalent is:
 
-* link:++https://www.javadoc.io/doc/org.assertj/assertj-core/latest/org/assertj/core/api/RecursiveComparisonAssert.html#withEqualsForFields(java.util.function.BiPredicate,java.lang.String...)++[`RecursiveComparisonAssert.withEqualsForFields(java.util.function.BiPredicate, String...)`] or
-* link:++https://www.javadoc.io/static/org.assertj/assertj-core/3.19.0/org/assertj/core/api/RecursiveComparisonAssert.html#withComparatorForFields(java.util.Comparator,java.lang.String...)++[`RecursiveComparisonAssert.withComparatorForFields(Comparator, String...)`]
+* {assertj-core-javadoc-root}org/assertj/core/api/RecursiveComparisonAssert.html#withEqualsForFields(java.util.function.BiPredicate,java.lang.String\...)[`RecursiveComparisonAssert.withEqualsForFields(java.util.function.BiPredicate, String...)`] or
+* {assertj-core-javadoc-root}org/assertj/core/api/RecursiveComparisonAssert.html#withComparatorForFields(java.util.Comparator,java.lang.String\...)[`RecursiveComparisonAssert.withComparatorForFields(Comparator, String...)`]
 
 and when using `usingRecursiveFieldByFieldElementComparator(RecursiveComparisonConfiguration config)`, sets the config with:
 
-* link:++https://www.javadoc.io/doc/org.assertj/assertj-core/latest/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.Builder.html#withEqualsForFields(java.util.function.BiPredicate,java.lang.String...)++[`RecursiveComparisonConfiguration.Builder.withEqualsForFields(java.util.function.BiPredicate, String...)`] or
-* link:++https://www.javadoc.io/doc/org.assertj/assertj-core/latest/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.Builder.html#withComparatorForFields(java.util.Comparator,java.lang.String...)++[`RecursiveComparisonConfiguration.Builder.withComparatorForFields(Comparator, String...)`]
+* {assertj-core-javadoc-root}org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.Builder.html#withEqualsForFields(java.util.function.BiPredicate,java.lang.String\...)[`RecursiveComparisonConfiguration.Builder.withEqualsForFields(java.util.function.BiPredicate, String...)`] or
+* {assertj-core-javadoc-root}org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.Builder.html#withComparatorForFields(java.util.Comparator,java.lang.String\...)[`RecursiveComparisonConfiguration.Builder.withComparatorForFields(Comparator, String...)`]
 
 [underline]#usingComparatorForElementFieldsWithType#
 
@@ -1042,13 +1042,13 @@ This method is used with `usingFieldByFieldElementComparator()` which is depreca
 
 When using `usingRecursiveComparison()` the equivalent is:
 
-* link:++https://www.javadoc.io/doc/org.assertj/assertj-core/latest/org/assertj/core/api/RecursiveComparisonAssert.html#withEqualsForType(java.util.function.BiPredicate,java.lang.Class)++[`RecursiveComparisonAssert.withEqualsForType(java.util.function.BiPredicate, Class)`] or
-* link:++https://www.javadoc.io/doc/org.assertj/assertj-core/latest/org/assertj/core/api/RecursiveComparisonAssert.html#withComparatorForType(java.util.Comparator,java.lang.Class)++[`RecursiveComparisonAssert.withComparatorForType(Comparator, Class)`]
+* {assertj-core-javadoc-root}org/assertj/core/api/RecursiveComparisonAssert.html#withEqualsForType(java.util.function.BiPredicate,java.lang.Class)[`RecursiveComparisonAssert.withEqualsForType(java.util.function.BiPredicate, Class)`] or
+* {assertj-core-javadoc-root}org/assertj/core/api/RecursiveComparisonAssert.html#withComparatorForType(java.util.Comparator,java.lang.Class)[`RecursiveComparisonAssert.withComparatorForType(Comparator, Class)`]
 
 and when] using `usingRecursiveFieldByFieldElementComparator(RecursiveComparisonConfiguration config)`, sets the config with:
 
-* link:++https://www.javadoc.io/doc/org.assertj/assertj-core/latest/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.Builder.html#withEqualsForType(java.util.function.BiPredicate,java.lang.Class)++[`RecursiveComparisonConfiguration.Builder.withEqualsForType(java.util.function.BiPredicate, Class)`] or
-* link:++https://www.javadoc.io/doc/org.assertj/assertj-core/latest/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.Builder.html#withComparatorForType(java.util.Comparator,java.lang.Class)++[`RecursiveComparisonConfiguration.Builder.withComparatorForType(Comparator, Class)`]
+* {assertj-core-javadoc-root}org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.Builder.html#withEqualsForType(java.util.function.BiPredicate,java.lang.Class)[`RecursiveComparisonConfiguration.Builder.withEqualsForType(java.util.function.BiPredicate, Class)`] or
+* {assertj-core-javadoc-root}org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.Builder.html#withComparatorForType(java.util.Comparator,java.lang.Class)[`RecursiveComparisonConfiguration.Builder.withComparatorForType(Comparator, Class)`]
 
 [[assertj-core-3.20.0-containsIgnoringWhitespaces]]
 [.release-note-item]#Add `containsIgnoringWhitespaces` to `String` assertions#
@@ -1342,7 +1342,7 @@ assertThat(Optional.of("a")).is(optionalWithLineSeparator)
 
 A `VerboseCondition` shows the value under test when it fails thanks to the specified `objectUnderTestDescriptor` function.
 
-When defining the `objectUnderTestDescriptor` function, you should take in consideration whether the condition is going to be used with link:https://www.javadoc.io/static/org.assertj/assertj-core/3.19.0/org/assertj/core/api/AbstractAssert.html#is(org.assertj.core.api.Condition)[`is(Condition)`] or link:https://www.javadoc.io/static/org.assertj/assertj-core/3.19.0/org/assertj/core/api/AbstractAssert.html#has(org.assertj.core.api.Condition)[`has(Condition)`] since the start of the error message is different between the two.
+When defining the `objectUnderTestDescriptor` function, you should take in consideration whether the condition is going to be used with {assertj-core-javadoc-root}org/assertj/core/api/AbstractAssert.html#is(org.assertj.core.api.Condition)[`is(Condition)`] or {assertj-core-javadoc-root}org/assertj/core/api/AbstractAssert.html#has(org.assertj.core.api.Condition)[`has(Condition)`] since the start of the error message is different between the two.
 
 Let's see how it works with an example that works well with `is(Condition)`:
 [source,java]
@@ -2441,7 +2441,7 @@ assertThat(future).succeedsWithin(200, TimeUnit.MILLISECONDS, as(STRING))
 
 Filters the iterable under test keeping only elements for which the result of the function is equal to expectedValue.
 
-It allows to filter elements more safely than by using https://www.javadoc.io/static/org.assertj/assertj-core/3.16.1/org/assertj/core/api/AbstractIterableAssert.html#filteredOn(java.lang.String,java.lang.Object)[`filteredOn(String, Object)`] as it doesn't utilize introspection.
+It allows to filter elements more safely than by using {assertj-core-javadoc-root}org/assertj/core/api/AbstractIterableAssert.html#filteredOn(java.lang.String,java.lang.Object)[`filteredOn(String, Object)`] as it doesn't utilize introspection.
 
 As an example, let's check all employees 800 years old (yes, special employees):
 Examples:

--- a/src/docs/asciidoc/user-guide/assertj-core.adoc
+++ b/src/docs/asciidoc/user-guide/assertj-core.adoc
@@ -11,7 +11,7 @@ programmers writing tests assertions with AssertJ.
 
 AssertJ is a Java library that provides a rich set of assertions and truly helpful error messages, improves test code readability, and is designed to be super easy to use within your favorite IDE.
 
-http://www.javadoc.io/doc/org.assertj/assertj-core/ is the latest version of AssertJ Core Javadoc, each assertion is explained, most of them with code examples so be sure to check it if you want to know what a specific assertion does. 
+http://www.javadoc.io/doc/org.assertj/assertj-core/ is the latest version of AssertJ Core Javadoc, each assertion is explained, most of them with code examples so be sure to check it if you want to know what a specific assertion does.
 
 Here are a few examples of AssertJ assertions:
 
@@ -44,7 +44,7 @@ assertThatThrownBy(() -> { throw new Exception("boom!"); }).hasMessage("boom!");
 Throwable thrown = catchThrowable(() -> { throw new Exception("boom!"); });
 assertThat(thrown).hasMessageContaining("boom");
 
-// using the 'extracting' feature to check fellowshipOfTheRing character's names 
+// using the 'extracting' feature to check fellowshipOfTheRing character's names
 assertThat(fellowshipOfTheRing).extracting(TolkienCharacter::getName)
                                .doesNotContain("Sauron", "Elrond");
 
@@ -54,7 +54,7 @@ assertThat(fellowshipOfTheRing).extracting("name", "age", "race.name")
                                          tuple("Sam", 38, "Hobbit"),
                                          tuple("Legolas", 1000, "Elf"));
 
-// filtering a collection before asserting 
+// filtering a collection before asserting
 assertThat(fellowshipOfTheRing).filteredOn(character -> character.getName().contains("o"))
                                .containsOnly(aragorn, frodo, legolas, boromir);
 
@@ -77,7 +77,7 @@ Ask AssertJ related questions on {StackOverflow}.
 
 You are very welcome to suggest or contribute improvements to this guide, that's one great way to give back to open source projects!
 
-The repository containing the guide is https://github.com/assertj/doc, you can https://github.com/assertj/doc/issues[create a new issue], submit a pull request. Et voila!
+The repository containing the guide is {assertj-doc}, you can {assertj-doc}/issues[create a new issue], submit a pull request. Et voila!
 
 This guide is written with the awesome https://asciidoctor.org/docs/asciidoc-writers-guide/[Asciidoctor] which makes it easy to improve.
 

--- a/src/docs/asciidoc/user-guide/assertj-guava-assertions-guide.adoc
+++ b/src/docs/asciidoc/user-guide/assertj-guava-assertions-guide.adoc
@@ -25,22 +25,22 @@ This section describes the assertions provided by AssertJ Guava.
 |===
 |Assertion |Description
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/MultimapAssert.html#contains(org.assertj.core.data.MapEntry...)[`contains`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/MultimapAssert.html#contains(org.assertj.core.data.MapEntry\...)[`contains`]
 |Verifies that the actual `Multimap` contains the given entries.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/MultimapAssert.html#containsAllEntriesOf(com.google.common.collect.Multimap)[`containsAllEntriesOf`]
 |Verifies that the actual `Multimap` contains all entries of the given one (it might contain more entries).
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/MultimapAssert.html#containsKeys(K...)[`containsKeys`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/MultimapAssert.html#containsKeys(K\...)[`containsKeys`]
 |Verifies that the actual `Multimap` contains the given keys.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/MultimapAssert.html#containsValues(V...)[`containsValues`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/MultimapAssert.html#containsValues(V\...)[`containsValues`]
 |Verifies that the actual `Multimap` contains the given values for any key.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/MultimapAssert.html#doesNotContainKey(K)[`doesNotContainKey`]
 |Verifies that the actual `Multimap` does not contain the given key.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/MultimapAssert.html#doesNotContainKeys(K...)[`doesNotContainKeys`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/MultimapAssert.html#doesNotContainKeys(K\...)[`doesNotContainKeys`]
 |Verifies that the actual `Multimap` does not contain the given keys.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/MultimapAssert.html#hasSameEntriesAs(com.google.common.collect.Multimap)[`hasSameEntriesAs`]
@@ -102,10 +102,10 @@ In addition to `Iterable` {assertj-core-javadoc-root}org/assertj/core/api/Abstra
 |===
 |Assertion |Description
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeAssert.html#contains(T...)[`contains`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeAssert.html#contains(T\...)[`contains`]
 |Verifies that the actual `Range` contains the given values.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeAssert.html#doesNotContain(T...)[`doesNotContain`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeAssert.html#doesNotContain(T\...)[`doesNotContain`]
 |Verifies that the actual `Range` does not contain the given values.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeAssert.html#hasClosedLowerBound()[`hasClosedLowerBound`]
@@ -139,13 +139,13 @@ In addition to `Iterable` {assertj-core-javadoc-root}org/assertj/core/api/Abstra
 |===
 |Assertion |Description
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeMapAssert.html#contains(org.assertj.core.data.MapEntry...)[`contains`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeMapAssert.html#contains(org.assertj.core.data.MapEntry\...)[`contains`]
 |Verifies that the actual `RangeMap` contains the given entries.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeMapAssert.html#containsKeys(K...)[`containsKeys`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeMapAssert.html#containsKeys(K\...)[`containsKeys`]
 |Verifies that the actual `RangeMap` contains the given keys.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeMapAssert.html#containsValues(V...)[`containsValues`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeMapAssert.html#containsValues(V\...)[`containsValues`]
 |Verifies that the actual `RangeMap` contains the given values.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeMapAssert.html#isEmpty()[`isEmpty`]
@@ -161,25 +161,25 @@ In addition to `Iterable` {assertj-core-javadoc-root}org/assertj/core/api/Abstra
 |===
 |Assertion |Description
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#contains(T...)[`contains`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#contains(T\...)[`contains`]
 |Verifies that the given `RangeSet` contains the given ranges.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#containsAll(java.lang.Iterable)[`containsAll`]
 |Verifies that the given `RangeSet` contains all the given ranges.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#containsAnyOf(T...)[`containsAnyOf`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#containsAnyOf(T\...)[`containsAnyOf`]
 |Verifies that the given `RangeSet` contains at least one of the given ranges.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#containsAnyRangesOf(java.lang.Iterable)[`containsAnyRangesOf`]
 |Verifies that the given `RangeSet` contains at least one of the given ranges.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#doesNotContain(T...)[`doesNotContain`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#doesNotContain(T\...)[`doesNotContain`]
 |Verifies that the given `RangeSet` does not contain any of the given ranges.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#doesNotContainAll(java.lang.Iterable)[`doesNotContainAll`]
 |Verifies that the given `RangeSet` does not contain any of the given ranges.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#doesNotEnclose(com.google.common.collect.Range...)[`doesNotEnclose`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#doesNotEnclose(com.google.common.collect.Range\...)[`doesNotEnclose`]
 |Verifies that the given `RangeSet` does not enclose the given ranges.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#doesNotEncloseAnyRangesOf(com.google.common.collect.RangeSet)[`doesNotEncloseAnyRangesOf`]
@@ -188,7 +188,7 @@ In addition to `Iterable` {assertj-core-javadoc-root}org/assertj/core/api/Abstra
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#doesNotEncloseAnyRangesOf(java.lang.Iterable)[`doesNotEncloseAnyRangesOf`]
 |Verifies that the given `RangeSet` does not enclose any of the given ranges.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#doesNotIntersect(com.google.common.collect.Range...)[`doesNotIntersect`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#doesNotIntersect(com.google.common.collect.Range\...)[`doesNotIntersect`]
 |Verifies that the given `RangeSet` does not intersect the given ranges.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#doesNotIntersectAnyRangeFrom(com.google.common.collect.RangeSet)[`doesNotIntersectAnyRangeFrom`]
@@ -197,7 +197,7 @@ In addition to `Iterable` {assertj-core-javadoc-root}org/assertj/core/api/Abstra
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#doesNotIntersectAnyRangeFrom(java.lang.Iterable)[`doesNotIntersectAnyRangeFrom`]
 |Verifies that the given `RangeSet` does not intersect all the given ranges.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#encloses(com.google.common.collect.Range...)[`encloses`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#encloses(com.google.common.collect.Range\...)[`encloses`]
 |Verifies that the given `RangeSet` encloses the given ranges.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#enclosesAll(com.google.common.collect.RangeSet)[`enclosesAll`]
@@ -206,7 +206,7 @@ In addition to `Iterable` {assertj-core-javadoc-root}org/assertj/core/api/Abstra
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#enclosesAll(java.lang.Iterable)[`enclosesAll`]
 |Verifies that the given `RangeSet` encloses all the given ranges.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#enclosesAnyOf(com.google.common.collect.Range...)[`enclosesAnyOf`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#enclosesAnyOf(com.google.common.collect.Range\...)[`enclosesAnyOf`]
 |Verifies that the given `RangeSet` encloses at least one of the given ranges.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#enclosesAnyRangesOf(com.google.common.collect.RangeSet)[`enclosesAnyRangesOf`]
@@ -218,7 +218,7 @@ In addition to `Iterable` {assertj-core-javadoc-root}org/assertj/core/api/Abstra
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#hasSize(int)[`hasSize`]
 |Verifies that the given `RangeSet` has specific `size` of disconnected `Range` elements.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#intersects(com.google.common.collect.Range...)[`intersects`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#intersects(com.google.common.collect.Range\...)[`intersects`]
 |Verifies that the given `RangeSet` intersects all the given ranges.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#intersectsAll(com.google.common.collect.RangeSet)[`intersectsAll`]
@@ -227,7 +227,7 @@ In addition to `Iterable` {assertj-core-javadoc-root}org/assertj/core/api/Abstra
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#intersectsAll(java.lang.Iterable)[`intersectsAll`]
 |Verifies that the given `RangeSet` intersects all the given ranges.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#intersectsAnyOf(com.google.common.collect.Range...)[`intersectsAnyOf`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#intersectsAnyOf(com.google.common.collect.Range\...)[`intersectsAnyOf`]
 |Verifies that the given `RangeSet` intersects at least one of the given ranges.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/RangeSetAssert.html#intersectsAnyRangesOf(com.google.common.collect.RangeSet)[`intersectsAnyRangesOf`]
@@ -255,13 +255,13 @@ In addition to `Iterable` {assertj-core-javadoc-root}org/assertj/core/api/Abstra
 |{assertj-guava-javadoc-root}org/assertj/guava/api/TableAssert.html#containsCell(R,C,V)[`containsCell`]
 |Verifies that the actual `Table` contains the mapping of row/column to value.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/TableAssert.html#containsColumns(C...)[`containsColumns`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/TableAssert.html#containsColumns(C\...)[`containsColumns`]
 |Verifies that the actual `Table` contains the given columns.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/TableAssert.html#containsRows(R...)[`containsRows`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/TableAssert.html#containsRows(R\...)[`containsRows`]
 |Verifies that the actual `Table` contains the given rows.
 
-|{assertj-guava-javadoc-root}org/assertj/guava/api/TableAssert.html#containsValues(V...)[`containsValues`]
+|{assertj-guava-javadoc-root}org/assertj/guava/api/TableAssert.html#containsValues(V\...)[`containsValues`]
 |Verifies that the actual `Table` contains the given values for any key.
 
 |{assertj-guava-javadoc-root}org/assertj/guava/api/TableAssert.html#hasColumnCount(int)[`hasColumnCount`]
@@ -283,6 +283,6 @@ In addition to `Iterable` {assertj-core-javadoc-root}org/assertj/core/api/Abstra
 [[assertj-guava-javadoc]]
 === Javadoc
 
-The latest Javadoc for AssertJ Guava API is here: https://www.javadoc.io/doc/org.assertj/assertj-guava/latest/org/assertj/guava/api/package-summary.html
+The latest Javadoc for AssertJ Guava API is here: {assertj-guava-javadoc-roo}org/assertj/guava/api/package-summary.html
 
 

--- a/src/docs/asciidoc/user-guide/assertj-guava-quickstart.adoc
+++ b/src/docs/asciidoc/user-guide/assertj-guava-quickstart.adoc
@@ -93,7 +93,7 @@ assertThat(bestMovies).hasRowCount(5).hasColumnCount(3).hasSize(5)
                       .containsRows(1970, 1994, 2000, 2008, 2011);
 ----
 
-Note that you can find more working examples in the assertj-examples project: https://github.com/assertj/assertj-examples/tree/main/assertions-examples/src/test/java/org/assertj/examples/guava.
+Note that you can find more working examples in the assertj-examples project: {assertj-examples-repo}/tree/main/assertions-examples/src/test/java/org/assertj/examples/guava.
 
 [[assertj-guava-ide]]
 ==== IDE configuration

--- a/src/docs/asciidoc/user-guide/assertj-guava-release-notes.adoc
+++ b/src/docs/asciidoc/user-guide/assertj-guava-release-notes.adoc
@@ -3,7 +3,7 @@
 
 NOTE: AssertJ Guava main documentation is still in http://joel-costigliola.github.io/assertj/assertj-guava.html until it is moved to this website.
 
-The latest release notes can be found in the https://github.com/assertj/assertj/releases[GitHub releases].
+The latest release notes can be found in the {assertj-core-repo}/releases[GitHub releases].
 
 Older release notes:
 

--- a/src/docs/asciidoc/user-guide/assertj-joda-assertions-guide.adoc
+++ b/src/docs/asciidoc/user-guide/assertj-joda-assertions-guide.adoc
@@ -3,7 +3,7 @@
 
 This section describes the assertions provided by AssertJ Joda Time.
 
-In addition to specific type assertions, each type inherits assertions from http://www.javadoc.io/doc/org.assertj/assertj-core/latest/org/assertj/core/api/AbstractAssert.html[`org.assertj.core.api.AbstractAssert`].
+In addition to specific type assertions, each type inherits assertions from {assertj-core-javadoc-root}org/assertj/core/api/AbstractAssert.html[`org.assertj.core.api.AbstractAssert`].
 
 ==== LocalDate
 

--- a/src/docs/asciidoc/user-guide/assertj-joda-quickstart.adoc
+++ b/src/docs/asciidoc/user-guide/assertj-joda-quickstart.adoc
@@ -6,7 +6,7 @@ This guide is for the AssertJ Joda Time module.
 [[get-assertj-joda-time]]
 ==== Get assertj-joda-time library
 
-AssertJ Joda Time artifacts are in the Maven central repository. 
+AssertJ Joda Time artifacts are in the Maven central repository.
 
 [[assertj-joda-time-java-versions]]
 ===== Supported Java versions
@@ -87,7 +87,7 @@ assertThat(utcTime).as("in UTC time").isEqualTo(cestTime);
 
 You can compare `DateTime` to another `DateTime`, or `LocalDateTime` to `LocalDateTime`, but not `DateTime` to `LocalDateTime`, it doesn't make sense as one is timezone dependent and the other is not.
 
-Note that you can find more working examples in the https://github.com/assertj/assertj-examples/blob/main/assertions-examples/src/test/java/org/assertj/examples/JodaTimeAssertionsExamples.java[JodaTimeAssertionsExamples.java] class of the assertj-examples project.
+Note that you can find more working examples in the {assertj-examples-base-package}JodaTimeAssertionsExamples.java[JodaTimeAssertionsExamples.java] class of the assertj-examples project.
 
 [[assertj-joda-time-ide]]
 ==== IDE configuration


### PR DESCRIPTION
Latest JavaDoc pages include the module name in the URL.

This PR adds the module name to the URL path of `:assertj-core-javadoc-root:` and `:assertj-guava-javadoc-root:`.
Furthermore the following improvements are included:
* link-attributes are now consistently used among AssertJ Core, AssertJ Guava, and AssertJ Joda Time
* URLs including `...` needed to be escaped
* AssertJ DB was not touched for this PR